### PR TITLE
Send tx from dwrite if contract code found

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2672,6 +2672,8 @@
 
     "rpc-websockets/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
+    "seismic-bot/@types/bun": ["@types/bun@1.2.6", "", { "dependencies": { "bun-types": "1.2.6" } }, "sha512-fY9CAmTdJH1Llx7rugB0FpgWK2RKuHCs3g2cFDYXUutIy1QGiPQxKkGY8owhfZ4MXWNfxwIbQLChgH5gDsY7vw=="],
+
     "seismic-spammer/seismic-viem": ["seismic-viem@1.0.15", "", { "dependencies": { "@noble/ciphers": "^1.2.0", "@noble/curves": "^1.8.0", "@noble/hashes": "^1.7.0", "viem": "^2.21.50" } }, "sha512-xw6lZuZ0l1SeoAFfaqpIY2Hd09WtsjqKWlqtDqWZ3ZNStOCYEFR6m8W7MQYnc1fKpSV93JJNsV9m0GOoclPYXQ=="],
 
     "send/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -2787,6 +2789,8 @@
     "obj-multiplex/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "seismic-bot/@types/bun/bun-types": ["bun-types@1.2.6", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-FbCKyr5KDiPULUzN/nm5oqQs9nXCHD8dVc64BArxJadCvbNzAI6lUWGh9fSJZWeDIRD38ikceBU8Kj/Uh+53oQ=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 

--- a/packages/seismic-viem/src/contract/write.ts
+++ b/packages/seismic-viem/src/contract/write.ts
@@ -133,6 +133,7 @@ export type ShieldedWriteContractDebugResult<
 > = {
   plaintextTx: PlaintextTransactionParameters<TChain, TAccount>
   shieldedTx: SendSeismicTransactionParameters<TChain, TAccount>
+  txHash: `0x${string}` | null
 }
 
 /**
@@ -204,6 +205,17 @@ export async function shieldedWriteContractDebug<
     encryptionNonce
   )
 
+  const request: SendSeismicTransactionParameters<TChain, TAccount> = {
+    to: address,
+    data: shieldedData,
+    gas: gas!,
+    gasPrice: gasPrice!,
+    nonce: nonce!,
+    value,
+    encryptionPubkey: client.getEncryptionPublicKey(),
+    encryptionNonce,
+  }
+
   const baseTx = {
     to: address,
     gas: gas!,
@@ -211,6 +223,10 @@ export async function shieldedWriteContractDebug<
     nonce: nonce!,
     value,
   }
+
+  const code = await client.getCode({ address })
+  const txHash =
+    code !== undefined ? await sendShieldedTransaction(client, request) : null
 
   return {
     plaintextTx: {
@@ -223,5 +239,6 @@ export async function shieldedWriteContractDebug<
       encryptionPubkey: client.getEncryptionPublicKey(),
       encryptionNonce,
     },
+    txHash,
   }
 }


### PR DESCRIPTION
Want contract.dwrite([]) to send the transaction if connected to actual contract on network. The way we check that is via getCode(). If there's no code at that address or if the connection to the network is broken, return the plaintext + encrypted txs and a null value instead of tx hash