### PR TITLE
refactor: imports for better readability

### DIFF
--- a/tests/seismic-viem/src/viem.test.ts
+++ b/tests/seismic-viem/src/viem.test.ts
@@ -11,13 +11,15 @@ import {
 } from '@sviem-tests/index.ts'
 import { testAesKeygen } from '@sviem-tests/tests/aesKeygen.ts'
 import { testSeismicTxEncoding } from '@sviem-tests/tests/encoding.ts'
-import { testRng } from '@sviem-tests/tests/precompiles.ts'
-import { testHkdfHex } from '@sviem-tests/tests/precompiles.ts'
-import { testAesGcm } from '@sviem-tests/tests/precompiles.ts'
-import { testSecp256k1 } from '@sviem-tests/tests/precompiles.ts'
-import { testHkdfString } from '@sviem-tests/tests/precompiles.ts'
-import { testEcdh } from '@sviem-tests/tests/precompiles.ts'
-import { testRngWithPers } from '@sviem-tests/tests/precompiles.ts'
+import {
+  testRng,
+  testHkdfHex,
+  testAesGcm,
+  testSecp256k1,
+  testHkdfString,
+  testEcdh,
+  testRngWithPers,
+} from '@sviem-tests/tests/precompiles.ts'
 import {
   testLegacyTxTrace,
   testSeismicTxTrace,


### PR DESCRIPTION
i've consolidated the imports from `@sviem-tests/tests/precompiles.ts` into a single block to reduce redundancy and improve code readability.

this makes the code cleaner and easier to maintain.