### PR TITLE
Make sure encryption nonce has no leading zeroes

### DIFF
--- a/packages/seismic-react/package.json
+++ b/packages/seismic-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-react",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "React components for Seismic.",
   "type": "module",
   "main": "./dist/_cjs/index.js",
@@ -52,7 +52,7 @@
     "typescript": ">=5.0.4",
     "viem": "2.x",
     "wagmi": "^2.0.0",
-    "seismic-viem": ">=1.0.40"
+    "seismic-viem": ">=1.0.41"
   },
   "peerDependenciesMeta": {
     "typescript": {

--- a/packages/seismic-viem/package.json
+++ b/packages/seismic-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seismic-viem",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "Typescript interface for Seismic",
   "type": "module",
   "main": "./dist/_cjs/index.js",

--- a/packages/seismic-viem/src/crypto/nonce.ts
+++ b/packages/seismic-viem/src/crypto/nonce.ts
@@ -2,5 +2,23 @@ import { Hex, bytesToHex, trim } from 'viem'
 
 import { randomBytes } from '@noble/ciphers/webcrypto'
 
-export const randomEncryptionNonce = (): Hex =>
-  trim(bytesToHex(randomBytes(12)))
+export const randomEncryptionNonce = (): Hex => {
+  let nonce = bytesToHex(randomBytes(12))
+  while (nonce != trim(nonce)) {
+    /* 
+    TODO: this is a temporary fix.
+
+    RLP decoding fails because nonces are treated as uints and not bytes,
+    hence they cannot have leading zeroes.
+    
+    But we require exactly 12 bytes for the nonce
+
+    If nonce != trim(nonce), then the nonce has leading zeroes and is not valid.
+
+    This happens 1/256 times, so in that case we just try again
+    until it's fixed in (presumably) seismic-alloy
+    */
+    nonce = bytesToHex(randomBytes(12))
+  }
+  return nonce
+}

--- a/packages/seismic-viem/src/crypto/nonce.ts
+++ b/packages/seismic-viem/src/crypto/nonce.ts
@@ -1,5 +1,6 @@
-import { Hex, bytesToHex } from 'viem'
+import { Hex, bytesToHex, trim } from 'viem'
 
 import { randomBytes } from '@noble/ciphers/webcrypto'
 
-export const randomEncryptionNonce = (): Hex => bytesToHex(randomBytes(12))
+export const randomEncryptionNonce = (): Hex =>
+  trim(bytesToHex(randomBytes(12)))


### PR DESCRIPTION
currently the nonce is handled as a number, not bytes, so rlp encoding forces it to not have leading zeros. unclear if this is the correct solution, or whether we need to change nonce to be only bytes